### PR TITLE
Fix RISCOF local config

### DIFF
--- a/tools/compliance/config.ini
+++ b/tools/compliance/config.ini
@@ -13,4 +13,4 @@ compiler_name_prefix=riscv64-elf
 [sail_cSim]
 pluginpath=riscof-plugins/sail_cSim
 docker=True
-image=registry.gitlab.com/incoresemi/docker-images/compliance
+image=barabas5532/crush-ci:5


### PR DESCRIPTION
Our docker image includes about the same tools as the incoresemi docker image [1], so we can run locally with out docker image instead. The upstream image is quite outdated.

[1]: https://gitlab.com/incoresemi/docker-images/-/blob/e0a1354accad69cd37a5effeb766798676d6de6e/compliance/Dockerfile